### PR TITLE
Add ARB files extractor

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 strings2pot
 ===========
 
-strings2pot is useful to convert Apple .strings or Android/Java .xml files to POT gettext files.
+strings2pot is useful to convert Apple .strings, Android/Java .xml or Google app resource bundle .arb files to POT gettext files.
 
 
 Installation

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     version=VERSION,
     url='http://qurami.com/',
     license='MIT',
-    description='Converts Apple .strings or Android/Java .xml files to POT gettext files.',
+    description='Converts Apple .strings, Android/Java .xml or Google app resource bundle .arb files to POT gettext files.',
     long_description=LONG_DESCRIPTION,
     author='Gianfranco Reppucci',
     author_email='gianfranco.reppucci@qurami.com',

--- a/strings2pot/__init__.py
+++ b/strings2pot/__init__.py
@@ -10,5 +10,5 @@
     :license: MIT, see LICENSE for more details.
 """
 
-VERSION = '0.3.0'
+VERSION = '0.3.1'
 __version__ = VERSION

--- a/strings2pot/extractors/arb.py
+++ b/strings2pot/extractors/arb.py
@@ -1,0 +1,98 @@
+# -*- coding: utf-8 -*-
+
+import re
+import json
+
+class ArbExtractor:
+    def __init__(self, source_file, destination_file, context_id_generator):
+        self.source_file = source_file
+        self.destination_file = destination_file
+        self._create_context_id = context_id_generator
+    
+    def parse_string(self, string, placeholder_list):
+        for placeholder in placeholder_list:
+            string = string.replace("{%s}" % placeholder, '%s')
+        
+        s = string.replace('"', '\"')
+        s = s.replace("''", "'")
+        s = s.replace("\\n", "\n")
+
+        if "\n" in s:
+            s = s.replace("\n", "\\n\n")
+            parts = s.split("\n")
+            new_parts = ["\"\""]
+            for line in parts:
+                new_parts.append("\"%s\"" % line)
+
+            s = "\n".join(new_parts)
+        else:
+            s = "\"%s\"" % s
+        return s
+    
+    def split_plural_string(self, plural_string, plural_placeholder, placeholders):
+        split_strings = []
+
+        pattern = r"^{"+ plural_placeholder +",plural, (?P<imploded_string>.*)}"
+        prog = re.compile(pattern)
+
+        match = prog.match(plural_string)
+        if not match:
+            return []
+
+        imploded_string = match.groupdict()['imploded_string']
+
+        for placeholder in placeholders:
+            imploded_string = imploded_string.replace("{%s}" % placeholder, "_#|%s|#_" % placeholder)
+
+        while imploded_string != '':
+            entry = imploded_string[imploded_string.find('{')+1:imploded_string.find('}')]
+            for placeholder in placeholders:
+                entry = entry.replace("_#|%s|#_" % placeholder, "{%s}" % placeholder)
+            
+            split_strings.append(entry)
+            imploded_string = imploded_string[imploded_string.find('}')+1:]
+
+        return split_strings
+
+    def run(self):
+        with open(self.destination_file, 'a') as pot:
+            # open the arb file and convert it to a dictionary
+            # using json.load (arb is JSON in fact)
+            with open(self.source_file, 'r') as source:
+                source_as_dict = json.load(source)
+
+            # parse the arb dictionary
+            for key in source_as_dict:
+                # keys with @ prefix hold the placeholders,
+                # keys without it hold the string
+
+                # get placeholders for current key
+                placeholders = []
+                if key[0] == '@':
+                    for placeholder in source_as_dict[key]['placeholders']:
+                        placeholders.append(placeholder)
+
+                    # get string...
+                    source_string = source_as_dict[key[1:]]
+
+                    # check if it's a plural string
+                    strings_to_parse = [source_string]
+
+                    for placeholder in placeholders:
+                        if "{%s,plural" % placeholder in source_string:
+                            strings_to_parse = self.split_plural_string(source_string, placeholder, placeholders)
+                            break
+
+                    # then parse and add to pot found strings
+                    for string in strings_to_parse:
+                        parsed_string = self.parse_string(string, placeholders)
+                        message_id = parsed_string[1:len(parsed_string)-1]
+
+                        content = "\n#: %s:%s\nmsgctxt \"%s\"\nmsgid %s\nmsgstr \"\"\n" % (
+                            self.source_file,
+                            key,
+                            self._create_context_id(message_id),
+                            parsed_string
+                        )
+                        pot.write(content)
+            pot.close()

--- a/strings2pot/extractors/arb_test.py
+++ b/strings2pot/extractors/arb_test.py
@@ -1,0 +1,140 @@
+# -*- coding: utf-8 -*-
+
+import os
+import unittest
+import arb
+
+class ArbExtractorTest(unittest.TestCase):
+    def setUp(self):
+        self.mock_source_file = 'mock_source_arb.arb'
+        self.mock_destination_file = 'mock_destination_arb.pot'
+        def mock_context_id_generator(s): return 'MOCK_CONTEXT_ID'
+        self.mock_context_id_generator = mock_context_id_generator
+
+        with open(self.mock_source_file, 'a') as source_file:
+            source_file.write("""
+{
+	"testString": "That''s a \\"string\\"",
+	"@testString": {
+		"type": "text",
+		"placeholders": {}
+	},
+	"withPlaceholderstring": "Hello {name_withSomething}",
+	"@withPlaceholderstring": {
+		"type": "text",
+		"placeholders": {
+			"name_withSomething": {}
+		}
+	},
+	"pluralString": "{howMany,plural, =0{Dear {customerName}, your cart is empty}=1{Dear {customerName}, you''ve one item in your cart}other{Dear {customerName}, you have {howMany} items in your chart}}",
+	"@pluralString": {
+		"type": "text",
+		"placeholders": {
+			"howMany": {},
+			"customerName": {}
+		}
+	}
+}
+            """)
+    
+    def tearDown(self):
+        try:
+            os.unlink(self.mock_source_file)
+            os.unlink(self.mock_destination_file)
+        except Exception, e:
+            pass
+
+    # test that the ArbExtractor class constructor sets source_file and destination_file attributes
+    def test_ctor(self):
+        sut = arb.ArbExtractor(
+            self.mock_source_file,
+            self.mock_destination_file,
+            self.mock_context_id_generator
+        )
+
+        self.assertEqual(sut.source_file, self.mock_source_file)
+        self.assertEqual(sut.destination_file, self.mock_destination_file)
+
+    # test that ArbExtractor parse_string method converts string in POT format 
+    def test_parse_string(self):
+        sut = arb.ArbExtractor('', '', self.mock_context_id_generator)
+
+        single_line_string = "\' \" {placeholder}"
+        self.assertEqual(
+            sut.parse_string(single_line_string, ['placeholder']),
+            '"\' \" %s"'
+        )
+
+        multi_line_string = "\' \" \\n {placeholder}"
+        self.assertEqual(
+            sut.parse_string(multi_line_string, ['placeholder']),
+            '''""
+"\' \" \\n"
+" %s"'''
+        )
+    
+    # test that ArbExtractor split_plural_string method splits plural string in multiple strings
+    def test_split_plural_strings(self):
+        sut = arb.ArbExtractor('', '', self.mock_context_id_generator)
+
+        mock_multiple_string = "{howMany,plural, =0{Dear {customerName}, your cart is empty}=1{Dear {customerName}, you''ve one item in your cart}other{Dear {customerName}, you have {howMany} items in your chart}}"
+        self.assertEqual(
+            sut.split_plural_string(
+                mock_multiple_string,
+                'howMany',
+                ['howMany', 'customerName']
+            ),
+            [
+                "Dear {customerName}, your cart is empty",
+                "Dear {customerName}, you''ve one item in your cart",
+                "Dear {customerName}, you have {howMany} items in your chart"
+            ]
+        )
+
+    # test that ArbExtractor run method converts an input file in POT format
+    def test_run(self):
+        sut = arb.ArbExtractor(
+            self.mock_source_file,
+            self.mock_destination_file,
+            self.mock_context_id_generator
+        )
+
+        sut.run()
+
+        with open(self.mock_destination_file, 'r') as destination_file:
+            lines = destination_file.readlines()
+            pot_content_as_string = "".join(lines)
+
+            self.assertEqual(
+                pot_content_as_string,
+                """
+#: mock_source_arb.arb:@withPlaceholderstring
+msgctxt "MOCK_CONTEXT_ID"
+msgid "Hello %s"
+msgstr ""
+
+#: mock_source_arb.arb:@testString
+msgctxt "MOCK_CONTEXT_ID"
+msgid "That's a \"string\""
+msgstr ""
+
+#: mock_source_arb.arb:@pluralString
+msgctxt "MOCK_CONTEXT_ID"
+msgid "Dear %s, your cart is empty"
+msgstr ""
+
+#: mock_source_arb.arb:@pluralString
+msgctxt "MOCK_CONTEXT_ID"
+msgid "Dear %s, you've one item in your cart"
+msgstr ""
+
+#: mock_source_arb.arb:@pluralString
+msgctxt "MOCK_CONTEXT_ID"
+msgid "Dear %s, you have %s items in your chart"
+msgstr ""
+"""
+            )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/strings2pot/strings2pot.py
+++ b/strings2pot/strings2pot.py
@@ -7,7 +7,7 @@ import time
 import datetime
 import hashlib
 
-from extractors import android, ios
+from extractors import android, ios, arb
 
 class String2PotConverter:
     POT_HEADER = """msgid ""
@@ -35,8 +35,8 @@ class String2PotConverter:
             self.extractor = android.AndroidExtractor(source_file, destination_file, self._create_context_id)
         elif os.path.splitext(source_file)[1] == ".strings":
             self.extractor = ios.iOSExtractor(source_file, destination_file, self._create_context_id)
-        #elif os.path.splitext(source_file)[1] == ".arb":
-        #    self.extractor = ArbExtractor()
+        elif os.path.splitext(source_file)[1] == ".arb":
+            self.extractor = arb.ArbExtractor(source_file, destination_file, self._create_context_id)
         else:
             raise Exception("File format not recognized for source file %s" % (source_file))
 

--- a/strings2pot/strings2pot.py
+++ b/strings2pot/strings2pot.py
@@ -11,17 +11,17 @@ from extractors import android, ios, arb
 
 class String2PotConverter:
     POT_HEADER = """msgid ""
-    msgstr ""
-    "Project-Id-Version: PROJECT VERSION\\n"
-    "Report-Msgid-Bugs-To: EMAIL@ADDRESS\\n"
-    "POT-Creation-Date: %s\\n"
-    "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
-    "Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
-    "Language-Team: LANGUAGE <LL@li.org>\\n"
-    "MIME-Version: 1.0\\n"
-    "Content-Type: text/plain; charset=utf-8\\n"
-    "Content-Transfer-Encoding: 8bit\\n"
-    "Generated-By: strings2pot\\n"
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\\n"
+"Report-Msgid-Bugs-To: EMAIL@ADDRESS\\n"
+"POT-Creation-Date: %s\\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=utf-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
+"Generated-By: strings2pot\\n"
     """
     extractor = None
 


### PR DESCRIPTION
This branch introduces a new extractor for [ARB files](https://github.com/googlei18n/app-resource-bundle).

Please verify that the script is still working fine by writing a `test.arb` file such as:

```
{
	"testString": "This is a string",
	"@testString": {
		"type": "text",
		"placeholders": {}
	},
	"withPlaceholderstring": "Hello {name_withSomething}",
	"@withPlaceholderstring": {
		"type": "text",
		"placeholders": {
			"name_withSomething": {}
		}
	},
	"pluralString": "{howMany,plural, =0{Ciao {customerName}, your cart is empty}=1{Ciao {customerName}, you have one item in your cart}other{Ciao {customerName}, your cart contains {howMany} items}}",
	"@pluralString": {
		"type": "text",
		"placeholders": {
			"howMany": {},
			"customerName": {}
		}
	}
}
```

And trying to convert it via the following command:

`python strings2pot.py test.arb output.pot`

The `output.pot` should be a valid POT file containing all the strings, including all the plural ones.