### PR TITLE
Fix Android extractor

### DIFF
--- a/strings2pot/extractors/android.py
+++ b/strings2pot/extractors/android.py
@@ -11,6 +11,7 @@ class AndroidExtractor:
     
     def parse_string(self, string):
         s = string.replace("\\'", "'")
+        s = string.replace("\"", "\\\"")
         s = s.replace("\\n", "\n")
         s = re.sub(r'%\d\$s', '%s', s)
         s = re.sub(r'%\d\$d', '%d', s)

--- a/strings2pot/extractors/android_test.py
+++ b/strings2pot/extractors/android_test.py
@@ -43,14 +43,14 @@ class AndroidExtractorTest(unittest.TestCase):
         single_line_string = "\' \" %1$d %2$s"
         self.assertEqual(
             sut.parse_string(single_line_string),
-            '"\' \" %d %s"'
+            '"\' \\\" %d %s"'
         )
 
         multi_line_string = "\' \" \\n %1$s %1$d"
         self.assertEqual(
             sut.parse_string(multi_line_string),
             '''""
-"\' \" \\n"
+"\' \\\" \\n"
 " %s %d"'''
         )
     
@@ -73,7 +73,7 @@ class AndroidExtractorTest(unittest.TestCase):
                 '''
 #: mock_source_android.xml:3
 msgctxt "MOCK_CONTEXT_ID"
-msgid "Hello \"%s\", nice to see you here!"
+msgid "Hello \\\"%s\\\", nice to see you here!"
 msgstr ""
 '''
             )


### PR DESCRIPTION
This PR fixes a bug in the Android Extractor which caused the strings2pot to create bad PO files when a double quote was present.