### PR TITLE
Fix a bug when converting ARB files including non ASCII chars

### DIFF
--- a/strings2pot/extractors/arb.py
+++ b/strings2pot/extractors/arb.py
@@ -1,35 +1,47 @@
 # -*- coding: utf-8 -*-
+'''
+Creates a POT file from Dart's ARB file.
+'''
 
 import re
 import json
 
-class ArbExtractor:
+class ArbExtractor(object):
+    '''
+    Implements Extractor for ARB files.
+    '''
     def __init__(self, source_file, destination_file, context_id_generator):
         self.source_file = source_file
         self.destination_file = destination_file
         self._create_context_id = context_id_generator
-    
+
     def parse_string(self, string, placeholder_list):
+        '''
+        Formats a string into a POT valid string
+        '''
         for placeholder in placeholder_list:
             string = string.replace("{%s}" % placeholder, '%s')
-        
-        s = string.replace('"', '\"')
-        s = s.replace("''", "'")
-        s = s.replace("\\n", "\n")
 
-        if "\n" in s:
-            s = s.replace("\n", "\\n\n")
-            parts = s.split("\n")
+        parsed_string = string.replace('"', '\"')
+        parsed_string = parsed_string.replace("''", "'")
+        parsed_string = parsed_string.replace("\\n", "\n")
+
+        if "\n" in parsed_string:
+            parsed_string = parsed_string.replace("\n", "\\n\n")
+            parts = parsed_string.split("\n")
             new_parts = ["\"\""]
             for line in parts:
                 new_parts.append("\"%s\"" % line)
 
-            s = "\n".join(new_parts)
+            parsed_string = "\n".join(new_parts)
         else:
-            s = "\"%s\"" % s
-        return s
-    
+            parsed_string = "\"%s\"" % parsed_string
+        return parsed_string
+
     def split_plural_string(self, plural_string, plural_placeholder, placeholders):
+        '''
+        Converts ARB plural string into multiple POT strings
+        '''
         split_strings = []
 
         pattern = r"^{"+ plural_placeholder +",plural, (?P<imploded_string>.*)}"
@@ -42,19 +54,23 @@ class ArbExtractor:
         imploded_string = match.groupdict()['imploded_string']
 
         for placeholder in placeholders:
-            imploded_string = imploded_string.replace("{%s}" % placeholder, "_#|%s|#_" % placeholder)
+            imploded_string = \
+                imploded_string.replace("{%s}" % placeholder, "_#|%s|#_" % placeholder)
 
         while imploded_string != '':
             entry = imploded_string[imploded_string.find('{')+1:imploded_string.find('}')]
             for placeholder in placeholders:
                 entry = entry.replace("_#|%s|#_" % placeholder, "{%s}" % placeholder)
-            
+
             split_strings.append(entry)
             imploded_string = imploded_string[imploded_string.find('}')+1:]
 
         return split_strings
 
     def run(self):
+        '''
+        Extractor main method
+        '''
         with open(self.destination_file, 'a') as pot:
             # open the arb file and convert it to a dictionary
             # using json.load (arb is JSON in fact)
@@ -80,7 +96,8 @@ class ArbExtractor:
 
                     for placeholder in placeholders:
                         if "{%s,plural" % placeholder in source_string:
-                            strings_to_parse = self.split_plural_string(source_string, placeholder, placeholders)
+                            strings_to_parse = \
+                                self.split_plural_string(source_string, placeholder, placeholders)
                             break
 
                     # then parse and add to pot found strings

--- a/strings2pot/extractors/arb_test.py
+++ b/strings2pot/extractors/arb_test.py
@@ -8,7 +8,7 @@ class ArbExtractorTest(unittest.TestCase):
     def setUp(self):
         self.mock_source_file = 'mock_source_arb.arb'
         self.mock_destination_file = 'mock_destination_arb.pot'
-        def mock_context_id_generator(s): return 'MOCK_CONTEXT_ID'
+        def mock_context_id_generator(s): return u'MOCK_CONTEXT_ID'
         self.mock_context_id_generator = mock_context_id_generator
 
         with open(self.mock_source_file, 'a') as source_file:

--- a/strings2pot/strings2pot.py
+++ b/strings2pot/strings2pot.py
@@ -48,11 +48,23 @@ msgstr ""
     def convert(self):
         self.extractor.run()
 
+    def _clean_string(self, string):
+        """
+        Removes non ASCII chars from a string
+        """
+        clean_string = ""
+        for char in string:
+            if ord(char) < 127:
+                clean_string += char
+
+        return clean_string
+
     def _create_context_id(self, string):
         """
         Context strings will be used as string keys,
         so it is important to keep them unique from others
         """
+        string = self._clean_string(string)
 
         s = string.replace(' ', '_')  # convert spaces to underscores
         s = re.sub(r'\W', '', s)      # strip any NON-word char


### PR DESCRIPTION
This PR fixes a bug which caused strings2pot to fail when a Dart .arb file includes non-ASCII chars.

Verify that the converter works when using .arb files containing non-ASCII chars.