### PR TITLE
Fix Android extractor

### DIFF
--- a/strings2pot/__init__.py
+++ b/strings2pot/__init__.py
@@ -10,5 +10,5 @@
     :license: MIT, see LICENSE for more details.
 """
 
-VERSION = '0.3.3'
+VERSION = '0.3.4'
 __version__ = VERSION

--- a/strings2pot/extractors/android.py
+++ b/strings2pot/extractors/android.py
@@ -11,7 +11,7 @@ class AndroidExtractor:
     
     def parse_string(self, string):
         s = string.replace("\\'", "'")
-        s = string.replace("\"", "\\\"")
+        s = s.replace("\"", "\\\"")
         s = s.replace("\\n", "\n")
         s = re.sub(r'%\d\$s', '%s', s)
         s = re.sub(r'%\d\$d', '%d', s)

--- a/strings2pot/extractors/android_test.py
+++ b/strings2pot/extractors/android_test.py
@@ -40,7 +40,7 @@ class AndroidExtractorTest(unittest.TestCase):
     def test_parse_string(self):
         sut = android.AndroidExtractor('', '', self.mock_context_id_generator)
 
-        single_line_string = "\' \" %1$d %2$s"
+        single_line_string = "\\' \" %1$d %2$s"
         self.assertEqual(
             sut.parse_string(single_line_string),
             '"\' \\\" %d %s"'


### PR DESCRIPTION
This PR fixes a bug which caused strings2pot to create wrong POT files from Android XML files containing single quote characters.

Verify code and test it against [this example file](https://s3-eu-west-1.amazonaws.com/uploads-eu.hipchat.com/36998/260301/Xcsbg0R7gLBNJCV/strings.xml)