### PR TITLE
Return sys exit on exceptions

### DIFF
--- a/strings2pot/__init__.py
+++ b/strings2pot/__init__.py
@@ -10,5 +10,5 @@
     :license: MIT, see LICENSE for more details.
 """
 
-VERSION = '0.3.4'
+VERSION = '0.3.5'
 __version__ = VERSION

--- a/strings2pot/strings2pot.py
+++ b/strings2pot/strings2pot.py
@@ -94,6 +94,7 @@ def main():
             print "OK"
         except Exception, e:
             print e
+            sys.exit(1)
     else:
         _usage()
 


### PR DESCRIPTION
[Storia di riferimento](https://www.pivotaltracker.com/story/show/151165148)

Questa PR modifica il comportamento a strings2pot per restituire un errore al sistema quando si verificano eccezioni. Fino ad oggi infatti l'errore veniva solo stampato.

Verificare il codice.
